### PR TITLE
Initialize external backends earlier to allow backup and fallback to work

### DIFF
--- a/lib/mnesia/src/mnesia.hrl
+++ b/lib/mnesia/src/mnesia.hrl
@@ -39,6 +39,7 @@
 -define(ets_new_table(Tab, Props), _ = ets:new(Tab, Props)).
 -define(ets_delete_table(Tab), ets:delete(Tab)).
 -define(ets_fixtable(Tab, Bool), ets:fixtable(Tab, Bool)).
+-define(ets_give_away(Tab, Pid, GiftData), ets:give_away(Tab, Pid, GiftData)).
 
 
 -define(SAFE(OP), try (OP) catch error:_ -> ok end).

--- a/lib/mnesia/src/mnesia_bup.erl
+++ b/lib/mnesia/src/mnesia_bup.erl
@@ -83,7 +83,20 @@ iterate(Mod, Fun, Opaque, Acc) ->
     R = #restore{bup_module = Mod, bup_data = Opaque},
     try read_schema_section(R) of
 	{R2, {Header, Schema, Rest}} ->
-            Ext = get_ext_types(Schema),
+        Ext = get_ext_types(Schema),
+        case mnesia:system_info(is_running) of
+            Status when Status == yes orelse Status == starting ->
+                dbg_out("Status is ~p, initializing external backends.~n", [Status]),
+                Backends = mnesia_schema:get_backends_to_initialize(Ext),
+                mnesia_schema:init_backends(Backends);
+            _ ->
+                %% Do not initialize external backends if the system is not running
+                %% We can land here, if system is stopped and we're creating a schema
+                %% this triggers an implicit backup and fallback install
+                %% TODO: Is it really ok to skip here?
+                dbg_out("Skipping external backend initialization, mnesia is not running.~n", []),
+                ignore
+        end,
 	    try iter(R2, Header, Schema, Ext, Fun, Acc, Rest) of
 		{ok, R3, Res} ->
 		    close_read(R3),
@@ -745,12 +758,12 @@ do_fallback_start(true, false) ->
             ?SAFE(dets:close(schema)),
             TmpSchema = mnesia_lib:tab2tmp(schema),
             DatSchema = mnesia_lib:tab2dat(schema),
-	    AllLT  = ?ets_match_object(LocalTabs, '_'),
-	    ?ets_delete_table(LocalTabs),
+            AllLT  = ?ets_match_object(LocalTabs, '_'),
+            ?ets_delete_table(LocalTabs),
             case file:rename(TmpSchema, DatSchema) of
                 ok ->
-		    [(LT#local_tab.swap)(LT#local_tab.name, LT) ||
-			LT <- AllLT, LT#local_tab.name =/= schema],
+                    [(LT#local_tab.swap)(LT#local_tab.name, LT) ||
+                    LT <- AllLT, LT#local_tab.name =/= schema],
                     file:delete(BupFile),
                     ok;
                 {error, Reason} ->

--- a/lib/mnesia/src/mnesia_schema.erl
+++ b/lib/mnesia/src/mnesia_schema.erl
@@ -72,6 +72,8 @@
          info/1,
          init/1,
 	 init_backends/0,
+     init_backends/1,
+     get_backends_to_initialize/1,
          insert_cstruct/3,
 	 is_remote_member/1,
          list2cs/1,
@@ -161,13 +163,22 @@ init(IgnoreFallback) ->
     mnesia_controller:add_active_replica(schema, node()),
     init_backends().
 
-
 init_backends() ->
-    Backends = lists:foldl(fun({Alias, Mod}, Acc) ->
-				   orddict:append(Mod, Alias, Acc)
-			   end, orddict:new(), get_ext_types()),
-    [init_backend(Mod, Aliases) || {Mod, Aliases} <- Backends],
-    ok.
+    Backends = get_backends_to_initialize(get_ext_types()),
+    init_backends(Backends).
+init_backends([]) ->
+    ok;
+init_backends([{Mod, Aliases} = Backend | Rest]) ->
+    try init_backend(Mod, Aliases) of
+        ok ->
+            init_backends(Rest);
+        Other ->
+            verbose("Cannot initialize backend: ~p, Reason: ~p~n", [Backend, Other]),
+            init_backends(Rest)
+    catch error : {backend_already_initialized, _} ->
+        verbose("Backend: ~p is already initialized~n", [Backend]),
+        init_backends(Rest)
+    end.
 
 init_backend(Mod, [_|_] = Aliases) ->
     case Mod:init_backend() of
@@ -176,6 +187,10 @@ init_backend(Mod, [_|_] = Aliases) ->
 	Error ->
 	    mnesia:abort({backend_init_error, Error})
     end.
+
+get_backends_to_initialize(Ext) ->
+    lists:foldl(fun({Alias, Mod}, Acc) ->
+        orddict:append(Mod, Alias, Acc) end, orddict:new(), Ext).
 
 exit_on_error({error, Reason}) ->
     exit(Reason);

--- a/lib/mnesia/test/Makefile
+++ b/lib/mnesia/test/Makefile
@@ -54,6 +54,7 @@ MODULES= \
 	mnesia_cost \
 	mnesia_dbn_meters \
 	ext_test \
+	ext_test_server \
 	mnesia_index_plugin_test \
 	mnesia_external_backend_test
 

--- a/lib/mnesia/test/ext_test_server.erl
+++ b/lib/mnesia/test/ext_test_server.erl
@@ -1,0 +1,360 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(ext_test_server).
+
+-include("ext_test_server.hrl").
+
+%% This process is supposed to emulate external database process, it should not be linked
+%% to mnesia_monitor
+
+-export([tab_to_filename/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, terminate/2, code_change/3]).
+
+init(_) ->
+    ?DBG(),
+    {ok, []}.
+
+create_table(ext_ram_copies, Tab, Props) when is_atom(Tab) ->
+    case catch mnesia_lib:val({?MODULE, Tab}) of
+        Tid when is_reference(Tid) ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already created~n", [tab_to_list(Tab), Tid]);
+        _ ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p~n", [tab_to_list(Tab)]),
+            Tid = ets:new(Tab, [public, proplists:get_value(type, Props, set), {keypos, 2}]),
+            mnesia_lib:set({?MODULE, Tab}, Tid),
+            ?DBG("create_table, Alias, ext_ram_copies, Tab: ~p(~p)~n", [tab_to_list(Tab), Tid])
+    end,
+    ok;
+create_table(ext_disc_only_copies, Tab, Props) when is_atom(Tab) ->
+    case catch mnesia_lib:val({?MODULE, Tab}) of
+        Tab ->
+            ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p(~p) is already created~n", [tab_to_list(Tab), Tab]);
+        _ ->
+            ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p~n", [tab_to_list(Tab)]),
+            File = tab_to_filename(Tab),
+            false = filelib:is_regular(File),
+            {ok, Tab} = dets:open_file(Tab, [{type, proplists:get_value(type, Props, set)}, {keypos, 2}, {file, File}]),
+            mnesia_lib:set({?MODULE, Tab}, Tab),
+            ?DBG("create_table Alias: ext_disc_only_copies after dets:open_file, Tab: ~p~n", [tab_to_list(Tab)])
+    end,
+    ok;
+create_table(ext_ram_copies, Tag={Tab, index, {_Where, Type}}, _Opts) ->
+    case catch mnesia_lib:val({?MODULE, Tag}) of
+        Tid when is_reference(Tid) ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already created~n", [tab_to_list(Tag), Tid]);
+        _ ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p~n", [tab_to_list(Tag)]),
+            Tid = ets:new(tab_to_atom(Tag), [public, type_to_type_in_alias(ext_ram_copies, Type)]),
+            mnesia_lib:set({?MODULE, Tag}, Tid),
+            ?DBG("create_table, Alias, ext_ram_copies, Tab: ~p(~p)~n", [tab_to_list(Tag), Tid])
+    end,
+    ok;
+create_table(ext_disc_only_copies, Tag={Tab, index, {_Where, Type}}, _Opts) ->
+    case catch mnesia_lib:val({?MODULE, Tag}) of
+        Tag ->
+            ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p(~p) is already created~n", [tab_to_list(Tag), Tag]);
+        _ ->
+            ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p~n", [tab_to_list(Tag)]),
+            File = tab_to_filename(Tag),
+            false = filelib:is_regular(File),
+            {ok, Tag} = dets:open_file(Tag, [{type, type_to_type_in_alias(ext_disc_only_copies, Type)}, {file, File}]),
+            mnesia_lib:set({?MODULE, Tag}, Tag),
+            ?DBG("create_table Alias: ext_disc_only_copies after dets:open_file, Tab: ~p~n", [tab_to_list(Tag)])
+    end,
+    ok;
+create_table(ext_ram_copies, Tag={_Tab, retainer, {ChkPNumber, Node}}, _Opts) ->
+    case catch mnesia_lib:val({?MODULE, Tag}) of
+        Tid when is_reference(Tid) ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already created~n", [tab_to_list(Tag), Tid]);
+        _ ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p~n", [tab_to_list(Tag)]),
+            Tid = ets:new(tab_to_atom(Tag), [set, public, {keypos, 2}]),
+            mnesia_lib:set({?MODULE, Tag}, Tid),
+            ?DBG("create_table, Alias, ext_ram_copies, Tab: ~p(~p)~n", [tab_to_list(Tag), Tid])
+    end,
+    ok;
+create_table(ext_disc_only_copies, Tag={_Tab, retainer, {ChkPNumber, Node}}, _Opts) ->
+    case catch mnesia_lib:val({?MODULE, Tag}) of
+        Tag ->
+            ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p(~p) is already created~n", [tab_to_list(Tag), Tag]);
+        _ ->
+            ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p~n", [tab_to_list(Tag)]),
+            File = tab_to_filename(Tag),
+            false = filelib:is_regular(File),
+            {ok, Tag} = dets:open_file(Tag, [{type, set}, {keypos, 2}, {file, File}]),
+            mnesia_lib:set({?MODULE, Tag}, Tag),
+            ?DBG("create_table, Alias: ext_disc_only_copies after dets:open_file, Tab: ~p~n", [tab_to_list(Tag)])
+    end,
+    ok.
+
+receive_data(Data, ext_ram_copies, Name, Sender, {Name, Tab, Sender} = State) ->
+    ?DBG({Data, ext_ram_copies, Name, Sender, {Name, tab_to_list(Tab), Sender}}),
+    true = ets:insert(Tab, Data),
+    {more, State};
+receive_data(Data, ext_disc_only_copies, Name, Sender, {Name, Tab, Sender} = State) ->
+    ?DBG({Data, ext_disc_only_copies, Name, Sender, {Name, tab_to_list(Tab), Sender}}),
+    ok = dets:insert(Tab, Data),
+    {more, State};
+receive_data(Data, Alias, Tab, Sender, {Name, Sender} = State) ->
+    ?DBG({Data, Alias, tab_to_list(Tab), State}),
+    receive_data(Data, Alias, Tab, Sender, {Name, mnesia_lib:val({?MODULE, Tab}), Sender}).
+
+select(Alias, Tab, Ms) ->
+    Res = select(Alias, Tab, Ms, 100000),
+    select_1(Alias, Res).
+
+select_1(_Alias, '$end_of_table') -> [];
+select_1(ext_ram_copies, {Acc, C}) ->
+    case ets:select(C) of
+	'$end_of_table' -> Acc;
+	{New, Cont} ->
+	    select_1(ext_ram_copies, {New ++ Acc, Cont})
+    end;
+select_1(ext_disc_only_copies, {Acc, C}) ->
+    case dets:select(C) of
+    '$end_of_table' -> Acc;
+    {New, Cont} ->
+        select_1(ext_disc_only_copies, {New ++ Acc, Cont})
+    end.
+
+select(ext_ram_copies, Tab, Ms, Limit) when is_integer(Limit); Limit =:= infinity ->
+    ?DBG({ext_ram_copies, tab_to_list(Tab), Ms, Limit}),
+    ets:select(mnesia_lib:val({?MODULE, Tab}), Ms, Limit);
+select(ext_disc_only_copies, Tab, Ms, Limit) when is_integer(Limit); Limit =:= infinity ->
+    ?DBG({ext_disc_only_copies, tab_to_list(Tab), Ms, Limit}),
+    dets:select(mnesia_lib:val({?MODULE, Tab}), Ms, Limit).
+
+handle_call({create_table, Alias, Tab, Props}, _From, State) ->
+    ?DBG({create_table, Alias, tab_to_list(Tab), Props}),
+    Res = create_table(Alias, Tab, Props),
+    {reply, Res, State};
+
+handle_call({delete_table, ext_ram_copies, Tab}, _From, State) ->
+    ?DBG({delete_table, ext_ram_copies, tab_to_list(Tab)}),
+    try
+        ets:delete(mnesia_lib:val({?MODULE, Tab}))
+    catch _:_ ->
+        ?DBG("delete_table, ~p~n", {double_delete, tab_to_list(Tab)})
+    after
+        mnesia_lib:unset({?MODULE, Tab})
+    end,
+    {reply, ok, State};
+handle_call({delete_table, ext_disc_only_copies, Tab}, _From, State) ->
+    ?DBG({delete_table, ext_disc_only_copies, tab_to_list(Tab)}),
+    try
+        file:delete(tab_to_filename(Tab))
+    catch _:_ ->
+        ?DBG("delete_table, ~p~n", {double_delete, tab_to_list(Tab)})
+    after
+        mnesia_lib:unset({?MODULE, Tab})
+    end,
+    {reply, ok, State};
+
+handle_call({load_table, _Alias, _Tab, init_index, _Cs}, _From, State) ->
+    ?DBG({load_table, _Alias, tab_to_list(_Tab), init_index, _Cs}),
+    {reply, ok, State};
+handle_call({load_table, Alias, Tab, restore, Cs}, _From, State) ->
+    ?DBG({load_table, Alias, tab_to_list(Tab), restore, Cs}),
+    Res = create_table(Alias, Tab, mnesia_schema:cs2list(Cs)),
+    {reply, Res, State};
+handle_call({load_table, _Alias, Tab, _LoadReason, Cs}, _From, State) ->
+    ?DBG({load_table, _Alias, tab_to_list(Tab), _LoadReason, Cs}),
+    {reply, ok, State};
+
+handle_call({sender_init, Alias, Tab, _RemoteStorage, _Pid}, _From, State) ->
+    ?DBG({sender_init, Alias, tab_to_list(Tab), _RemoteStorage, _Pid}),
+    KeysPerTransfer = 100,
+    Res = {standard,
+        fun() -> mnesia_lib:db_init_chunk({ext, Alias, ?MODULE}, Tab, KeysPerTransfer) end,
+        fun(Cont) -> mnesia_lib:db_chunk({ext, Alias, ?MODULE}, Cont) end},
+    {reply, Res, State};
+
+handle_call({receive_data, Data, Alias, Name, Sender, MnesiaState}, _From, State) ->
+    ?DBG({receive_data, Data, Alias, Name, Sender, MnesiaState}),
+    Res = receive_data(Data, Alias, Name, Sender, MnesiaState),
+    {reply, Res, State};
+
+handle_call({sync_close_table, ext_ram_copies, _Tab}, _From, State) ->
+    ?DBG({sync_close_table, ext_ram_copies, tab_to_list(_Tab)}),
+    {reply, ok, State};
+handle_call({sync_close_table, ext_disc_only_copies, Tab}, _From, State) ->
+    ?DBG({sync_close_table, ext_disc_only_copies, tab_to_list(Tab)}),
+    ok = dets:sync(Tab),
+    ok = dets:close(Tab),
+    {reply, ok, State};
+
+handle_call({fixtable, ext_ram_copies, Tab, Bool}, _From, State) ->
+    ?DBG({fixtable, ext_ram_copies, tab_to_list(Tab), Bool}),
+    Res = ets:safe_fixtable(mnesia_lib:val({?MODULE, Tab}), Bool),
+    {reply, Res, State};
+handle_call({fixtable, ext_disc_only_copies, Tab, Bool}, _From, State) ->
+    ?DBG({fixtable, ext_disc_only_copies, tab_to_list(Tab), Bool}),
+    Res = dets:safe_fixtable(mnesia_lib:val({?MODULE, Tab}), Bool),
+    {reply, Res, State};
+
+handle_call({info, ext_ram_copies, Tab, Type}, _From, State) ->
+    ?DBG({info, ext_ram_copies, tab_to_list(Tab), Type}),
+    Tid = mnesia_lib:val({?MODULE, Tab}),
+    Res = try ets:info(Tid, Type) of
+	Val -> Val
+    catch _:_ ->
+	    undefined
+    end,
+    {reply, Res, State};
+handle_call({info, ext_disc_only_copies, Tab, Type}, _From, State) ->
+    ?DBG({info, ext_disc_only_copies, tab_to_list(Tab), Type}),
+    Tid = mnesia_lib:val({?MODULE, Tab}),
+    Res = try dets:info(Tid, Type) of
+    Val -> Val
+    catch _:_ ->
+        undefined
+    end,
+    {reply, Res, State};
+
+handle_call({insert, ext_ram_copies, Tab, Obj}, _From, State) ->
+    ?DBG({insert, ext_ram_copies, tab_to_list(Tab), Obj}),
+    true = ets:insert(mnesia_lib:val({?MODULE, Tab}), Obj),
+    {reply, ok, State};
+handle_call({insert, ext_disc_only_copies, Tab, Obj}, _From, State) ->
+    ?DBG({insert, ext_disc_only_copies, tab_to_list(Tab), Obj}),
+    ok = dets:insert(mnesia_lib:val({?MODULE, Tab}), Obj),
+    {reply, ok, State};
+
+handle_call({lookup, ext_ram_copies, Tab, Key}, _From, State) ->
+    ?DBG({lookup, ext_ram_copies, tab_to_list(Tab), Key}),
+    Res = ets:lookup(mnesia_lib:val({?MODULE, Tab}), Key),
+    {reply, Res, State};
+handle_call({lookup, ext_disc_only_copies, Tab, Key}, _From, State) ->
+    ?DBG({lookup, ext_disc_only_copies, tab_to_list(Tab), Key}),
+    Res = dets:lookup(mnesia_lib:val({?MODULE, Tab}), Key),
+    {reply, Res, State};
+
+handle_call({delete, ext_ram_copies, Tab, Key}, _From, State) ->
+    ?DBG({delete, ext_ram_copies, tab_to_list(Tab), Key}),
+    Res = ets:delete(mnesia_lib:val({?MODULE, Tab}), Key),
+    {reply, Res, State};
+handle_call({delete, ext_disc_only_copies, Tab, Key}, _From, State) ->
+    ?DBG({delete, ext_disc_only_copies, tab_to_list(Tab), Key}),
+    Res = dets:delete(mnesia_lib:val({?MODULE, Tab}), Key),
+    {reply, Res, State};
+
+handle_call({match_delete, ext_ram_copies, Tab, Pat}, _From, State) ->
+    ?DBG({match_delete, ext_ram_copies, tab_to_list(Tab), Pat}),
+    Res = ets:match_delete(mnesia_lib:val({?MODULE, Tab}), Pat),
+    {reply, Res, State};
+handle_call({match_delete, ext_disc_only_copies, Tab, Pat}, _From, State) ->
+    ?DBG({match_delete, ext_disc_only_copies, tab_to_list(Tab), Pat}),
+    Res = dets:match_delete(mnesia_lib:val({?MODULE, Tab}), Pat),
+    {reply, Res, State};
+
+handle_call({first, ext_ram_copies, Tab}, _From, State) ->
+    ?DBG({first, ext_ram_copies, tab_to_list(Tab)}),
+    Res = ets:first(mnesia_lib:val({?MODULE, Tab})),
+    {reply, Res, State};
+handle_call({first, ext_disc_only_copies, Tab}, _From, State) ->
+    ?DBG({first, ext_disc_only_copies, tab_to_list(Tab)}),
+    Res = dets:first(mnesia_lib:val({?MODULE, Tab})),
+    {reply, Res, State};
+
+handle_call({next, ext_ram_copies, Tab, Key}, _From, State) ->
+    ?DBG({next, ext_ram_copies, tab_to_list(Tab), Key}),
+    Res = ets:next(mnesia_lib:val({?MODULE, Tab}), Key),
+    {reply, Res, State};
+handle_call({next, ext_disc_only_copies, Tab, Key}, _From, State) ->
+    ?DBG({next, ext_disc_only_copies, tab_to_list(Tab), Key}),
+    Res = dets:next(mnesia_lib:val({?MODULE, Tab}), Key),
+    {reply, Res, State};
+
+handle_call({slot, ext_ram_copies, Tab, Pos}, _From, State) ->
+    ?DBG({slot, ext_ram_copies, tab_to_list(Tab), Pos}),
+    Res = ets:slot(mnesia_lib:val({?MODULE, Tab}), Pos),
+    {reply, Res, State};
+handle_call({slot, ext_disc_only_copies, Tab, Pos}, _From, State) ->
+    ?DBG({slot, ext_disc_only_copies, tab_to_list(Tab), Pos}),
+    Res = dets:slot(mnesia_lib:val({?MODULE, Tab}), Pos),
+    {reply, Res, State};
+
+handle_call({update_counter, ext_ram_copies, Tab, C, Val}, _From, State) ->
+    ?DBG({update_counter, ext_ram_copies, tab_to_list(Tab), C, Val}),
+    Res = ets:update_counter(mnesia_lib:val({?MODULE, Tab}), C, Val),
+    {reply, Res, State};
+handle_call({update_counter, ext_disc_only_copies, Tab, C, Val}, _From, State) ->
+    ?DBG({update_counter, ext_disc_only_copies, tab_to_list(Tab), C, Val}),
+    Res = dets:update_counter(mnesia_lib:val({?MODULE, Tab}), C, Val),
+    {reply, Res, State};
+
+handle_call({select, '$end_of_table' = End}, _From, State) ->
+    ?DBG({select, End}),
+    {reply, End, State};
+handle_call({select, {ext_ram_copies, C}}, _From, State) ->
+    ?DBG({select, {ext_ram_copies, C}}),
+    Res = ets:select(C),
+    {reply, Res, State};
+handle_call({select, {ext_disc_only_copies, C}}, _From, State) ->
+    ?DBG({select, {ext_disc_only_copies, C}}),
+    Res = dets:select(C),
+    {reply, Res, State};
+
+handle_call({select, Alias, Tab, Ms}, _From, State) ->
+    ?DBG({select, Alias, tab_to_list(Tab), Ms}),
+    Res = select(Alias, Tab, Ms),
+    {reply, Res, State};
+
+handle_call({select, Alias, Tab, Ms, Limit}, _From, State) ->
+    ?DBG({select, Alias, tab_to_list(Tab), Ms, Limit}),
+    Res = select(Alias, Tab, Ms, Limit),
+    {reply, Res, State};
+
+handle_call({repair_continuation, Cont, Ms}, _From, State) ->
+    ?DBG({repair_continuation, Cont, Ms}),
+    Res = case element(1, Cont) of
+        dets_cont ->
+            dets:repair_continuation(Cont, Ms);
+        _ ->
+            ets:repair_continuation(Cont, Ms)
+    end,
+    {reply, Res, State}.
+
+terminate(Reason, _State) ->
+    ?DBG(Reason).
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+tab_to_atom(Tab) ->
+    list_to_atom(tab_to_list(Tab)).
+tab_to_list(Tab) when is_atom(Tab) ->
+    atom_to_list(Tab);
+tab_to_list({Tab, index, {Where, Type}}) ->
+    atom_to_list(Tab) ++ "_index_" ++ integer_to_list(Where) ++ "_" ++ atom_to_list(Type);
+tab_to_list({Tab, retainer, {ChkPNumber, Node}}) ->
+    atom_to_list(Tab) ++ "_retainer_" ++ integer_to_list(ChkPNumber) ++ "_" ++ atom_to_list(Node).
+
+type_to_type_in_alias(ext_ram_copies, ordered) ->
+    ordered_set;
+type_to_type_in_alias(_, Type) ->
+    Type.
+
+tab_to_filename(Tab) ->
+    FName = tab_to_list(Tab) ++ ".dat.ext",
+    mnesia_lib:dir(FName).

--- a/lib/mnesia/test/ext_test_server.hrl
+++ b/lib/mnesia/test/ext_test_server.hrl
@@ -1,0 +1,31 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2022. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-ifdef(DEBUG).
+-define(DBG(), io:format("~p:~p: ~p~n",[?MODULE, ?LINE, ?FUNCTION_NAME])).
+-define(DBG(DATA), io:format("~p:~p: ~p, ~p~n",[?MODULE, ?LINE, ?FUNCTION_NAME, DATA])).
+-define(DBG(FORMAT, ARGS), io:format("~p:~p: ~p," ++ FORMAT,[?MODULE, ?LINE, ?FUNCTION_NAME] ++ ARGS)).
+-else.
+-define(DBG(), ok).
+-define(DBG(DATA), ok).
+-define(DBG(FORMAT, ARGS), ok).
+-endif.
+
+-define(SERVER, ext_test_server).

--- a/lib/mnesia/test/mnesia_config_test.erl
+++ b/lib/mnesia/test/mnesia_config_test.erl
@@ -730,8 +730,8 @@ backend_plugin_registration(doc) ->
 backend_plugin_registration(Config) when is_list(Config) ->
     Nodes = ?acquire_schema(1, [{default_properties, []} | Config]),
     ?match(ok, mnesia:start()),
-    ?match({atomic,ok}, mnesia:add_backend_type(ext_ets, ext_test)),
-    ?match({atomic,ok}, mnesia:add_backend_type(ext_dets, ext_test)),
+    ?match({atomic,ok}, mnesia:add_backend_type(ext_ram_copies, ext_test)),
+    ?match({atomic,ok}, mnesia:add_backend_type(ext_disc_only_copies, ext_test)),
     ?verify_mnesia(Nodes, []),
     ?cleanup(1, Config).
 

--- a/lib/mnesia/test/mnesia_external_backend_test.erl
+++ b/lib/mnesia/test/mnesia_external_backend_test.erl
@@ -4,9 +4,13 @@
          init_per_group/2, end_per_group/2,
          suite/0, all/0, groups/0]).
 
--export([conversion_from_external_to_disc_copies_results_in_data_loss_after_node_restart/1]).
+-export([
+    conversion_from_external_to_disc_copies_results_in_data_loss_after_node_restart/1,
+    backup_and_restore_fails_with_external_backend/1
+]).
 
 -include("mnesia_test_lib.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
 
 -record(some_rec, {some_id :: atom(), some_int :: number(), some_string :: string()}).
 
@@ -15,17 +19,27 @@
                                            delete_schema],
                                           N, Config, ?FILE, ?LINE)).
 
-all() -> 
-    [conversion_from_external_to_disc_copies_results_in_data_loss_after_node_restart].
+all() -> [
+    backup_and_restore_fails_with_external_backend
+].
 
 groups() ->
     [].
 
 init_per_testcase(Func, Conf) ->
+    file:delete(ext_test_server:tab_to_filename(table)),
+    file:delete("bup0.BUP"),
+    file:delete("bup1.BUP"),
+    file:delete("bup2.BUP"),
+    {ok, _} = gen_server:start_link({local, ext_test_server}, ext_test_server, [self()],
+                               [{timeout, infinity}
+                                %%, {debug, [trace]}
+                               ]),
     mnesia_test_lib:init_per_testcase(Func, Conf).
 
 end_per_testcase(Func, Conf) ->
-    mnesia_test_lib:end_per_testcase(Func, Conf).
+    mnesia_test_lib:end_per_testcase(Func, Conf),
+    ok = gen_server:stop(ext_test_server).
 
 init_per_group(_GroupName, Config) ->
     Config.
@@ -77,3 +91,62 @@ conversion_from_external_to_disc_copies_results_in_data_loss_after_node_restart(
     Data = mnesia:activity(transaction, fun() ->
         mnesia:match_object(table, #some_rec{_ = '_'}, read) end
     ).
+
+backup_and_restore_fails_with_external_backend(Config) when is_list(Config) ->
+    Node = node(),
+    Data1 = [
+        #some_rec{some_id = a, some_int = 1, some_string = "1"},
+        #some_rec{some_id = b, some_int = 2, some_string = "2"},
+        #some_rec{some_id = c, some_int = 3, some_string = "3"}
+    ],
+    Data2 = [
+        #some_rec{some_id = d, some_int = 4, some_string = "4"},
+        #some_rec{some_id = e, some_int = 5, some_string = "5"},
+        #some_rec{some_id = f, some_int = 6, some_string = "6"}
+    ],
+
+    [Node] = ?acquire_nodes(1, Config),
+    ?match({atomic, ok}, mnesia:create_table(table, [
+        {type, set},
+        {record_name, some_rec},
+        {attributes, record_info(fields, some_rec)},
+        {ext_disc_only_copies, [Node]}
+    ])),
+
+    % ?match({atomic, ok}, mnesia:add_table_index(table, #some_rec.some_int)).
+    ?match([], mnesia:dirty_match_object(table, #some_rec{_ = '_'})),
+    % ?match(ok, mnesia:backup("bup0.BUP")),
+
+    ?match(ok, mnesia:activity(transaction, fun() ->
+        lists:foreach(fun(Elem) -> mnesia:write(table, Elem, write) end, Data1)
+    end)),
+    ?match(ok, mnesia:backup("bup1.BUP")),
+
+    % ?match(ok, mnesia:activity(transaction, fun() ->
+    %     lists:foreach(fun(Elem) -> mnesia:write(table, Elem, write) end, Data2)
+    % end)),
+    % ?match(ok, mnesia:backup("bup2.BUP")),
+
+    % ?match(true, ets:whereis(table) =/= undefined),
+    % ?match(ok, load_backup("bup0.BUP")).
+    % ?match(true, ets:whereis(table) =/= undefined),
+    % ?match([], mnesia:dirty_match_object(table, #some_rec{_ = '_'})).
+    % [] = mnesia:dirty_index_read(table, 2, #some_rec.some_int),
+
+    ?match(ok, load_backup("bup1.BUP")),
+    Expected1 = sets:from_list(Data1),
+    ?match(Expected1, sets:from_list(mnesia:dirty_match_object(table, #some_rec{_ = '_'}))).
+    % [#some_rec{some_id = b, some_int = 2, some_string = "2"}] = mnesia:dirty_index_read(table, 2, #some_rec.some_int),
+
+    % ?match(ok, load_backup("bup2.BUP")),
+    % Expected2 = sets:from_list(lists:append(Data1, Data2)),
+    % ?match(Expected2, sets:from_list(mnesia:dirty_match_object(table, #some_rec{_ = '_'}))).
+    % [#some_rec{some_id = b, some_int = 2, some_string = "2"}] = mnesia:dirty_index_read(table, 2, #some_rec.some_int),
+    % [#some_rec{some_id = e, some_int = 5, some_string = "5"}] = mnesia:dirty_index_read(table, 5, #some_rec.some_int).
+
+load_backup(BUP) ->
+    ok = mnesia:install_fallback(BUP),
+    stopped = mnesia:stop(),
+    timer:sleep(3000),
+    ok = mnesia:start(),
+    ok = mnesia:wait_for_tables([schema, table], 5000).

--- a/lib/mnesia/test/mnesia_test_lib.erl
+++ b/lib/mnesia/test/mnesia_test_lib.erl
@@ -1031,9 +1031,10 @@ verify_replica_location(Tab, DiscOnly0, Ram0, Disc0, AliveNodes0) ->
     timer:sleep(100),
 
     S1 = ?match(AliveNodes, lists:sort(mnesia:system_info(running_db_nodes))),
-    S2 = ?match(DiscOnly, lists:sort(mnesia:table_info(Tab, disc_only_copies))),
+    S2 = ?match(DiscOnly, lists:sort(mnesia:table_info(Tab, disc_only_copies) ++
+					mnesia:table_info(Tab, ext_disc_only_copies))),
     S3 = ?match(Ram, lists:sort(mnesia:table_info(Tab, ram_copies) ++
-				    mnesia:table_info(Tab, ext_ets))),
+				    mnesia:table_info(Tab, ext_ram_copies))),
     S4 = ?match(Disc, lists:sort(mnesia:table_info(Tab, disc_copies))),
     S5 = ?match(Write, lists:sort(mnesia:table_info(Tab, where_to_write))),
     S6 = case lists:member(This, Read) of

--- a/lib/mnesia/test/mnesia_test_lib.hrl
+++ b/lib/mnesia/test/mnesia_test_lib.hrl
@@ -151,4 +151,4 @@
 -define(verify_mnesia(Ups, Downs),
 	mnesia_test_lib:verify_mnesia(Ups, Downs, ?FILE, ?LINE)).
 
--define(BACKEND, [{backend_types, [{ext_ets, ext_test},{ext_dets, ext_test}]}]).
+-define(BACKEND, [{backend_types, [{ext_ram_copies, ext_test},{ext_disc_only_copies, ext_test}]}]).


### PR DESCRIPTION
In current code, external backends are only initialized when mnesia finishes initializing schema. This is too late because backup traversal already tried to execute, causing a crash.

Fixes: #8045